### PR TITLE
El 45 setup the frontend repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "stations-management"]
 	path = stations-management
 	url = git@github.com:elytra-tqs/stations-management.git
+[submodule "frontend"]
+	path = frontend
+	url = git@github.com:elytra-tqs/frontend.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,17 @@ services:
       - JAVA_OPTS=-Dspring.devtools.restart.enabled=true -Dspring.devtools.livereload.enabled=true
       - SPRING_PROFILES_ACTIVE=dev
     restart: unless-stopped
+    networks:
+      - elytra
+  elytra-frontend:
+    build: ./frontend
+    container_name: frontend
+    ports:
+      - "5173:5173"
+    command: npm run dev
+    networks:
+      - elytra
+
+networks:
+  elytra:
+    driver: bridge


### PR DESCRIPTION
This pull request introduces a new `frontend` submodule and updates the `docker-compose.yml` file to integrate it into the development environment. The changes primarily focus on adding the frontend project as a submodule and configuring Docker to support it.

### Submodule Addition:
* Added a new submodule for the `frontend` project in `.gitmodules` with its path set to `frontend` and its repository URL specified. (`.gitmodules`, [.gitmodulesR7-R9](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R7-R9))
* Linked the `frontend` submodule to the specific commit `684e36355b8da380fd1af358ac84ed692b5b8f62`. (`frontend`, [frontendR1](diffhunk://#diff-1cf387c012cd2d02f1923e589f86df4a4802427057dbc90f47b87f04d29d54bcR1))

### Docker Configuration:
* Updated `docker-compose.yml` to include a new service `elytra-frontend` for the frontend project, specifying its build context, container name, ports, and command to run the development server. (`docker-compose.yml`, [docker-compose.ymlR15-R28](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R15-R28))
* Added a custom Docker network named `elytra` to ensure proper communication between containers. (`docker-compose.yml`, [docker-compose.ymlR15-R28](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R15-R28))