### PR TITLE
El 49 create GitHub action to update main repository for each push from submodules

### DIFF
--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -1,0 +1,49 @@
+name: Update Submodule Reference
+on:
+  repository_dispatch:
+    types: [submodule-updated]
+
+permissions:                     # ← mandatory since GITHUB_TOKEN
+  contents: write                #   is read-only by default
+
+jobs:
+  update-submodule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo & sub-modules
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_PAT }}   # 👈 same token
+          fetch-depth: 0
+          submodules: recursive          # pulls private sub-modules too
+
+      - name: Git identity
+        run: |
+          git config --global user.name  'GitHub Actions Bot'
+          git config --global user.email 'actions@github.com'
+
+      - name: Switch to dev
+        run: git checkout dev
+
+      - name: Find sub-module path
+        id: path
+        run: |
+          REPO_NAME=$(basename "${{ github.event.client_payload.submodule_name }}")
+          SUB_PATH=$(git config -f .gitmodules --get-regexp path | grep "$REPO_NAME" | awk '{print $2}')
+          echo "path=$SUB_PATH" >>"$GITHUB_OUTPUT"
+
+      - name: Update pointer
+        run: |
+          cd "${{ steps.path.outputs.path }}"
+          git fetch origin
+          git checkout ${{ github.event.client_payload.commit_sha }}
+          cd -
+          git add "${{ steps.path.outputs.path }}"
+          if ! git diff --cached --quiet; then
+            git commit -m "Update ${{
+              steps.path.outputs.path }} → ${{ github.event.client_payload.commit_sha }}"
+            git push \
+              "https://x-access-token:${{ secrets.BOT_PAT }}@github.com/${{ github.repository }}.git" \
+              HEAD:dev           # ← PAT as HTTPS password :contentReference[oaicite:4]{index=4}
+          fi
+

--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -3,8 +3,8 @@ on:
   repository_dispatch:
     types: [submodule-updated]
 
-permissions:                     # ← mandatory since GITHUB_TOKEN
-  contents: write                #   is read-only by default
+permissions:
+  contents: write
 
 jobs:
   update-submodule:
@@ -13,9 +13,9 @@ jobs:
       - name: Checkout repo & sub-modules
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.BOT_PAT }}   # 👈 same token
+          token: ${{ secrets.BOT_PAT }}
           fetch-depth: 0
-          submodules: recursive          # pulls private sub-modules too
+          submodules: recursive
 
       - name: Git identity
         run: |
@@ -44,6 +44,6 @@ jobs:
               steps.path.outputs.path }} → ${{ github.event.client_payload.commit_sha }}"
             git push \
               "https://x-access-token:${{ secrets.BOT_PAT }}@github.com/${{ github.repository }}.git" \
-              HEAD:dev           # ← PAT as HTTPS password :contentReference[oaicite:4]{index=4}
+              HEAD:dev
           fi
 


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the process of updating submodule references in the repository. The workflow listens for a `repository_dispatch` event and updates the submodule pointer to a specified commit.

### Automation for submodule updates:
* [`.github/workflows/submodule_update.yml`](diffhunk://#diff-f91ae1bf8113a2e6fa914aefa1b498c9939c0edd97f6abed3139ada7000b3570R1-R49): Added a new workflow named "Update Submodule Reference" to handle submodule updates. It includes steps to check out the repository and submodules, configure Git identity, switch to the `dev` branch, determine the submodule path, update the submodule pointer to the specified commit, and push changes back to the `dev` branch.