### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/deploy-prod-docker.yml
+++ b/.github/workflows/deploy-prod-docker.yml
@@ -15,16 +15,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Make deploy script executable
         run: chmod +x deploy.sh
 
       - name: Run deployment script
         run: ./deploy.sh
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker compose -f docker-compose.prod.yml down

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,15 +2,23 @@
 
 set -e
 
-echo "Starting production deployment..."
-
-echo "Updating submodules..."
-git submodule update --remote --recursive
-
 echo "Stopping existing containers..."
 docker compose -f docker-compose.prod.yml down
+
+git pull
+
+git submodule foreach git pull
+
+echo "Starting production deployment..."
+
+echo "Verifying submodules are present..."
+if [ ! -f "stations-management/Dockerfile" ]; then
+    echo "Error: stations-management Dockerfile not found"
+    exit 1
+fi
+
 
 echo "Building and starting production containers..."
 docker compose -f docker-compose.prod.yml up --build -d
 
-echo "Production deployment completed successfully!" 
+echo "Production deployment completed successfully!"


### PR DESCRIPTION
This pull request refactors the deployment process by moving container cleanup and submodule updates from the GitHub Actions workflow to the `deploy.sh` script. It also adds a verification step to ensure submodule integrity during deployment.

### Deployment process refactoring:

* [`.github/workflows/deploy-prod-docker.yml`](diffhunk://#diff-014dd0d962f7d9417baf10fbaa225600b1653f92f7a5b7f9925b2019313c72b9L18-L30): Removed steps for submodule updates and container cleanup from the GitHub Actions workflow. These responsibilities are now handled within the `deploy.sh` script.

* [`deploy.sh`](diffhunk://#diff-30883d1df2fc62f59d66255a70dc05f60d3d4ef4d3957e6e3e38e62f6e471bd0R5-L11): Added commands to stop existing containers (`docker compose down`) and pull the latest changes for the repository and its submodules. Introduced a verification step to ensure the presence of the `stations-management/Dockerfile`. The script now handles submodule updates and container cleanup directly.