### PR TITLE
El 1139 jwt secret injection into docker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,6 +20,7 @@ services:
       dockerfile: Dockerfile.prod
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - JWT_SECRET=${JWT_SECRET}
     restart: unless-stopped
     networks:
       - elytra

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
     environment:
       - JAVA_OPTS=-Dspring.devtools.restart.enabled=true -Dspring.devtools.livereload.enabled=true
       - SPRING_PROFILES_ACTIVE=dev
+      - JWT_SECRET=${JWT_SECRET}
     restart: unless-stopped
     networks:
       - elytra


### PR DESCRIPTION
This pull request updates the `docker-compose` configuration files to include a new environment variable for JWT authentication. The changes ensure that the `JWT_SECRET` variable is passed to the application in both production and development environments.

### Environment variable addition for JWT authentication:

* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R23): Added `JWT_SECRET` to the environment variables under the `services` section to support JWT authentication in the production environment.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R56): Added `JWT_SECRET` to the environment variables under the `services` section to support JWT authentication in the development environment.